### PR TITLE
Add input macro to system function

### DIFF
--- a/llamascript/__init__.py
+++ b/llamascript/__init__.py
@@ -207,7 +207,9 @@ class Llama:
             self.data = prompt_text
         debug(f"Prompt set to: {self.data}")
 
-    def system_command(self, system_content, _):
+    def system_command(self, system_content, attributes):
+        if "input" in attributes:
+            system_content = input(system_content)
         self.system = [{"role": "system", "content": system_content}]
         debug(f"System command set.")
 


### PR DESCRIPTION
Fixes #47

This PR adds the feature of using the input macro with the system function like so:
```llamascript
use("llama3.2")
prompt("Say 'Hello, World!'")
#[input(true)]
system("What should the AI do? ")
chat()
```